### PR TITLE
Removed hr/min/sec reset to zero in conversion[Date]

### DIFF
--- a/src/parse-wrapper.js
+++ b/src/parse-wrapper.js
@@ -19,14 +19,7 @@
 		      return Boolean(Number(value));
 		    },
 		    'Date': function(value) {
-		      if(value instanceof Date) {
-		        var newDate = new Date(value.valueOf() + value.getTimezoneOffset() * 60000);
-		        newDate.setSeconds(0);
-		        newDate.setMinutes(0);
-		        newDate.setHours(0);
-		        return newDate;
-		      }
-		      return moment(value, wrapParse.dateFormat).toDate();
+		      return (value instanceof Date) ? value : moment(value, wrapParse.dateFormat).toDate();
 		    },
 		    'Relation': function(value, fieldType) {
 		      if(value instanceof fieldType)


### PR DESCRIPTION
Date should be saved as is. Any formatting of the time fields need to be done explicitly by the client so that there are not surprises.

If the resetting of time fields to zero was done deliberately, would you be interested in expressing that as a parameter in the field specification? i.e., the `dateOnly` parameter in the example below

``` javascript
var MyModel = wrapParse('MyModel', {
    timestamp: {type: Date, dateOnly: true},  //by thefault dateOnly would be false
});
```

If so, let me know, I'll code that up and contribute.
