### PR TITLE
guard against bug when defaultValue is obj or array

### DIFF
--- a/src/parse-wrapper.js
+++ b/src/parse-wrapper.js
@@ -53,7 +53,15 @@
 		        configurable: false,
 		        get: function() {
 		          var value = this.get(fieldName);
-		          value = value === undefined ? defaultValue : value;
+		          if(value === undefined){
+		            //when defaultVal is needed, give this model its own copy.
+		            //this matters if defaultVal is a js object or array that can be changed
+		            //subsequently by the client, we don't want the changes to be applied to
+		            //the one copy of defaultVal that's shared with other models of the wrapped class.
+		            this.parseWrapperDefaults = this.parseWrapperDefaults || {};
+		            if(!_.has(this.parseWrapperDefaults, fieldName)) this.parseWrapperDefaults[fieldName] = _.clone(defaultValue);
+		            value = this.parseWrapperDefaults[fieldName];
+		          }
 
 		          if(value !== undefined && fieldType.name === 'Boolean')
 		            return conversion['Boolean'](value);


### PR DESCRIPTION
When the specified defaultValue is specified as a javascript object or array, e.g., {} or [], our wrapped property will return the reference to that object/array. A user can then make intermediate modifications to our copy of this object/array and this copy will be shared with all other models of the same wrapped class.

Instead of returning a clone of defaultValue every time the get method is called (which makes angular scope digest mechanism go crazy), I saved at most 1 clone of the defaultValue per model per field and return that reference to the client when get() is invoked.