### PR TITLE
only do conversion for fields user intended to save or dirty fields

### DIFF
--- a/src/parse-wrapper.js
+++ b/src/parse-wrapper.js
@@ -95,15 +95,16 @@
 		          this.set(data);
 		    		}
 
-		        this.beforeSave();
-		        this.parseFields();
+		        this.beforeSave.apply(this, arguments);
+		        this.parseFields(data);
 
 		    		return originalSave.apply(this, arguments);
 		    	},
 
-		      parseFields: function () {
+		      parseFields: function (data) {
 		        var self = this;
-		        _.forOwn(cols, function(fieldType, fieldName) {
+		        var fields = _.isEmpty(data) ? _.pick(cols, this.dirtyKeys()) : _.pick(cols, _.keys(data));
+		        _.forOwn(fields, function(fieldType, fieldName) {
 		          var type = fieldType.name || fieldType._name;
 
 		          if (self[fieldName] !== undefined && typeof conversion[type] === 'function') {


### PR DESCRIPTION
When user call `save(attrObj)` with an attribute object, this fix makes sure that only those attributes get modified/converted in our wrapper. When the user call `save()` without an attribute object, only the dirty keys are converted before calling `originalSave`.

This way, clean keys don't get marked dirty by Parse. Knowing which key is dirty/not dirty is useful info for beforeSave hooks on cloud code.
